### PR TITLE
fix: correctly handle skipped and excluded tests.

### DIFF
--- a/lib/buildkite_test_collector/test_result.ex
+++ b/lib/buildkite_test_collector/test_result.ex
@@ -62,16 +62,18 @@ defmodule BuildkiteTestCollector.TestResult do
   """
   @spec new(ExUnit.Test.t(), Duration.t() | nil, Duration.t() | nil) :: t
   def new(%ExUnit.Test{} = test, start_time \\ nil, end_time \\ nil) do
+    location = "#{test.tags.file}:#{test.tags.line}"
+
     %TestResult{
       id: UUID.generate(),
-      scope: inspect(test.tags.module),
-      name: [test.tags.describe, test.tags.test] |> Enum.filter(& &1) |> Enum.join(" "),
-      identifier: "#{test.tags.file}:#{test.tags.line}",
-      location: "#{test.tags.file}:#{test.tags.line}",
+      scope: extract_test_scope(test),
+      name: extract_test_name(test),
+      identifier: location,
+      location: location,
       file_name: test.tags.file,
-      result: result(test.state),
-      failure_reason: failure_reason(test.state),
-      failure_expanded: failure_expanded(test.state),
+      result: extract_test_result(test.state),
+      failure_reason: extract_failure_reason(test.state),
+      failure_expanded: extract_failure_expanded(test.state),
       history: %{
         section: "top",
         start_at: start_time,
@@ -81,22 +83,72 @@ defmodule BuildkiteTestCollector.TestResult do
     }
   end
 
-  defp result(nil), do: "passed"
-  defp result(_state), do: "failed"
+  defp extract_test_scope(%{module: module, tags: %{describe: description}})
+       when is_binary(description),
+       do: "#{inspect(module)} #{description}"
 
-  defp failure_reason(nil), do: nil
+  defp extract_test_scope(%{module: module}), do: inspect(module)
 
-  defp failure_reason({:failed, [{:error, %{__exception__: true} = error, _} | _]}),
-    do: error_message(error)
+  defp extract_test_name(%{module: module, tags: %{describe: description}, name: name})
+       when is_binary(description),
+       do: "#{inspect(module)} #{description} #{name}"
 
-  defp failure_expanded(nil), do: nil
-  defp failure_expanded({:failed, failures}), do: Enum.map(failures, &expand_failure/1)
+  defp extract_test_name(%{module: module, name: name}), do: "#{inspect(module)} #{name}"
 
-  defp expand_failure({:error, %{__exception__: true} = error, _location}),
-    do: %{
-      error: inspect(error.__struct__),
-      message: error_message(error)
-    }
+  defp extract_test_result(nil), do: "passed"
+  defp extract_test_result({:failed, _}), do: "failed"
+  defp extract_test_result({:skipped, _}), do: "skipped"
+  defp extract_test_result({:invalid, _}), do: "skipped"
+  defp extract_test_result({:excluded, _}), do: "skipped"
 
-  defp error_message(error), do: error |> Exception.message() |> String.trim()
+  defp extract_failure_reason(
+         {:failed, [{:error, %ExUnit.AssertionError{message: message}, _} | _]}
+       ),
+       do: message
+
+  defp extract_failure_reason({:failed, [{:error, exception, _} | _]})
+       when is_exception(exception),
+       do:
+         exception
+         |> Exception.message()
+         |> String.replace(~r/\s+/, " ")
+         |> String.trim()
+
+  defp extract_failure_reason({:failed, [{kind, payload, stacktrace} | _]}),
+    do:
+      Exception.format_banner(kind, payload, stacktrace)
+      |> String.replace(~r/\s+/, " ")
+      |> String.trim()
+
+  defp extract_failure_reason({:invalid, _}), do: "failure in setup_all callback"
+
+  defp extract_failure_reason(_), do: nil
+
+  defp extract_failure_expanded({:failed, errors}) do
+    errors
+    |> Enum.map(fn {kind, payload, stacktrace} ->
+      message_lines =
+        Exception.format_banner(kind, payload)
+        |> into_lines()
+
+      stacktrace_lines =
+        stacktrace
+        |> Exception.format_stacktrace()
+        |> into_lines()
+
+      %{expanded: message_lines, backtrace: stacktrace_lines}
+    end)
+  end
+
+  defp extract_failure_expanded({:invalid, %ExUnit.TestModule{state: state}}),
+    do: state |> extract_failure_expanded()
+
+  defp extract_failure_expanded(_), do: nil
+
+  defp into_lines(string),
+    do:
+      string
+      |> String.split(~r/[\r\n]+/)
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(&(byte_size(&1) == 0))
 end

--- a/test/buildkite_test_collector/test_result_test.exs
+++ b/test/buildkite_test_collector/test_result_test.exs
@@ -2,103 +2,69 @@ defmodule BuildkiteTestCollector.TestResultTest do
   @moduledoc false
 
   use ExUnit.Case, async: false
-
+  import BuildkiteTestCollector.ExUnitDataHelpers
   alias BuildkiteTestCollector.TestResult
 
-  describe "build result for passing test" do
-    test "simplest passing test" do
-      result =
-        TestResult.new(%ExUnit.Test{
-          state: nil,
-          tags: %{
-            case: TestModule,
-            module: TestModule,
-            describe: nil,
-            describe_line: nil,
-            test: :"passing test",
-            file: "test.exs",
-            line: 12
-          },
-          time: 5_000_000
-        })
+  test "passing test" do
+    result =
+      passing_test()
+      |> TestResult.new()
 
-      assert %{
-               id: _,
-               scope: "TestModule",
-               name: "passing test",
-               identifier: "test.exs:12",
-               location: "test.exs:12",
-               file_name: "test.exs",
-               result: "passed",
-               failure_reason: nil,
-               failure_expanded: nil,
-               history: %{
-                 section: "top",
-                 start_at: nil,
-                 end_at: nil,
-                 duration: 5.0
-               }
-             } = result
-    end
+    assert result.result == "passed"
+    assert result.scope == "PassingTest"
+    refute result.failure_reason
+    refute result.failure_expanded
+  end
 
-    test "simplest failing test" do
-      result =
-        TestResult.new(%ExUnit.Test{
-          state:
-            {:failed,
-             [
-               {:error,
-                %ExUnit.AssertionError{
-                  args: :ex_unit_no_meaningful_value,
-                  context: :==,
-                  doctest: :ex_unit_no_meaningful_value,
-                  expr: {:assert, [], [false]},
-                  left: :ex_unit_no_meaningful_value,
-                  message: "Expected truthy, got false",
-                  right: :ex_unit_no_meaningful_value
-                },
-                [
-                  {TestModule, :"test failing", 1,
-                   [file: 'test/buildkite_test_collector/formatter_test.exs', line: 38]}
-                ]}
-             ]},
-          tags: %{
-            async: false,
-            case: TestModule,
-            module: TestModule,
-            describe: nil,
-            describe_line: nil,
-            test: :"failing test",
-            file: "test.exs",
-            line: 12,
-            registered: %{},
-            test_type: :test
-          },
-          time: 5_000_000
-        })
+  test "failing test" do
+    result =
+      failing_test()
+      |> TestResult.new()
 
-      assert %BuildkiteTestCollector.TestResult{
-               id: _,
-               scope: "TestModule",
-               name: "failing test",
-               identifier: "test.exs:12",
-               location: "test.exs:12",
-               file_name: "test.exs",
-               result: "failed",
-               failure_reason: "Expected truthy, got false\ncode: assert false",
-               failure_expanded: [
-                 %{
-                   error: "ExUnit.AssertionError",
-                   message: "Expected truthy, got false\ncode: assert false"
-                 }
-               ],
-               history: %{
-                 section: "top",
-                 start_at: nil,
-                 end_at: nil,
-                 duration: 5.0
-               }
-             } = result
-    end
+    assert result.result == "failed"
+    assert result.scope == "FailingTest"
+    assert result.failure_reason == "Expected false or nil, got true"
+
+    [%{expanded: messages, backtrace: stacktrace}] = result.failure_expanded
+
+    assert Enum.join(stacktrace, "\n") =~ ~r/failing_test.exs:6/
+    assert Enum.join(messages, "\n") =~ ~r/AssertionError/
+  end
+
+  test "skipped test" do
+    result =
+      skipped_test()
+      |> TestResult.new()
+
+    assert result.result == "skipped"
+    assert result.scope == "SkippedTest"
+    refute result.failure_reason
+    refute result.failure_expanded
+  end
+
+  test "invalid test" do
+    result =
+      invalid_test()
+      |> TestResult.new()
+
+    assert result.result == "skipped"
+    assert result.scope == "InvalidTest"
+    assert result.failure_reason == "failure in setup_all callback"
+
+    [%{expanded: messages, backtrace: stacktrace}] = result.failure_expanded
+
+    assert Enum.join(stacktrace, "\n") =~ ~r/setup_all/
+    assert Enum.join(messages, "\n") =~ ~r/RuntimeError/
+  end
+
+  test "excluded test" do
+    result =
+      excluded_test()
+      |> TestResult.new()
+
+    assert result.result == "skipped"
+    assert result.scope == "PassingTest"
+    refute result.failure_reason
+    refute result.failure_expanded
   end
 end

--- a/test/support/exunit_data_helpers.ex
+++ b/test/support/exunit_data_helpers.ex
@@ -7,17 +7,24 @@ defmodule BuildkiteTestCollector.ExUnitDataHelpers do
   @spec passing_test :: ExUnit.Test.t()
   def passing_test do
     %ExUnit.Test{
+      case: PassingTest,
+      logs: "",
+      module: PassingTest,
+      name: :"test passing",
       state: nil,
       tags: %{
-        case: TestModule,
-        module: TestModule,
+        async: false,
+        case: PassingTest,
         describe: nil,
         describe_line: nil,
-        test: :"passing test",
-        file: "test.exs",
-        line: 12
+        file: "test/support/fixture_tests/passing_test.exs",
+        line: 5,
+        module: PassingTest,
+        registered: %{},
+        test: :"test passing",
+        test_type: :test
       },
-      time: 5
+      time: 3
     }
   end
 
@@ -25,17 +32,149 @@ defmodule BuildkiteTestCollector.ExUnitDataHelpers do
   @spec failing_test :: ExUnit.Test.t()
   def failing_test do
     %ExUnit.Test{
-      state: nil,
+      case: FailingTest,
+      logs: "",
+      module: FailingTest,
+      name: :"test failing",
+      state:
+        {:failed,
+         [
+           {:error,
+            %ExUnit.AssertionError{
+              args: :ex_unit_no_meaningful_value,
+              context: :==,
+              doctest: :ex_unit_no_meaningful_value,
+              expr: {:refute, [], [true]},
+              left: :ex_unit_no_meaningful_value,
+              message: "Expected false or nil, got true",
+              right: :ex_unit_no_meaningful_value
+            },
+            [
+              {FailingTest, :"test failing", 1,
+               [file: 'test/support/fixture_tests/failing_test.exs', line: 6]}
+            ]}
+         ]},
       tags: %{
-        case: TestModule,
-        module: TestModule,
+        async: false,
+        case: FailingTest,
         describe: nil,
         describe_line: nil,
-        test: :"passing test",
-        file: "test.exs",
-        line: 12
+        file: "test/support/fixture_tests/failing_test.exs",
+        line: 5,
+        module: FailingTest,
+        registered: %{},
+        test: :"test failing",
+        test_type: :test
       },
-      time: 5
+      time: 4020
+    }
+  end
+
+  @doc false
+  @spec skipped_test :: ExUnit.Test.t()
+  def skipped_test do
+    %ExUnit.Test{
+      case: SkippedTest,
+      logs: "",
+      module: SkippedTest,
+      name: :"test skipped",
+      state: {:skipped, "due to skip tag"},
+      tags: %{
+        async: false,
+        describe: nil,
+        describe_line: nil,
+        file: "test/support/fixture_tests/skipped_test.exs",
+        line: 6,
+        registered: %{},
+        skip: true,
+        test_type: :test
+      },
+      time: 0
+    }
+  end
+
+  @doc false
+  @spec invalid_test :: ExUnit.Test.t()
+  def invalid_test do
+    %ExUnit.Test{
+      case: InvalidTest,
+      logs: "",
+      module: InvalidTest,
+      name: :"test invalid",
+      state:
+        {:invalid,
+         %ExUnit.TestModule{
+           file: "test/support/fixture_tests/invalid_test.exs",
+           name: InvalidTest,
+           state:
+             {:failed,
+              [
+                {:error, %RuntimeError{message: "hell"},
+                 [
+                   {InvalidTest, :__ex_unit_setup_all_0, 1,
+                    [
+                      file: 'test/support/fixture_tests/invalid_test.exs',
+                      line: 6,
+                      error_info: %{module: Exception}
+                    ]},
+                   {InvalidTest, :__ex_unit__, 2,
+                    [file: 'test/support/fixture_tests/invalid_test.exs', line: 1]}
+                 ]}
+              ]},
+           tests: [
+             %ExUnit.Test{
+               case: InvalidTest,
+               logs: "",
+               module: InvalidTest,
+               name: :"test invalid",
+               state: nil,
+               tags: %{
+                 async: false,
+                 describe: nil,
+                 describe_line: nil,
+                 file: "test/support/fixture_tests/invalid_test.exs",
+                 line: 9,
+                 registered: %{},
+                 test_type: :test
+               },
+               time: 0
+             }
+           ]
+         }},
+      tags: %{
+        async: false,
+        describe: nil,
+        describe_line: nil,
+        file: "test/support/fixture_tests/invalid_test.exs",
+        line: 9,
+        module: InvalidTest,
+        registered: %{},
+        test: :"test invalid",
+        test_type: :test
+      },
+      time: 0
+    }
+  end
+
+  @doc false
+  @spec excluded_test :: ExUnit.Test.t()
+  def excluded_test do
+    %ExUnit.Test{
+      case: PassingTest,
+      logs: "",
+      module: PassingTest,
+      name: :"test passing",
+      state: {:excluded, "due to test filter"},
+      tags: %{
+        async: false,
+        describe: nil,
+        describe_line: nil,
+        file: "test/support/fixture_tests/passing_test.exs",
+        line: 5,
+        registered: %{},
+        test_type: :test
+      },
+      time: 0
     }
   end
 end

--- a/test/support/fixture_tests/failing_test.exs
+++ b/test/support/fixture_tests/failing_test.exs
@@ -1,0 +1,10 @@
+defmodule FailingTest do
+  use ExUnit.Case
+  @moduledoc false
+
+  @moduletag fixture: true
+
+  test "failing" do
+    refute true
+  end
+end

--- a/test/support/fixture_tests/invalid_test.exs
+++ b/test/support/fixture_tests/invalid_test.exs
@@ -1,0 +1,14 @@
+defmodule InvalidTest do
+  use ExUnit.Case
+  @moduledoc false
+
+  @moduletag fixture: true
+
+  setup_all do
+    raise "hell"
+  end
+
+  test "invalid" do
+    assert true
+  end
+end

--- a/test/support/fixture_tests/passing_test.exs
+++ b/test/support/fixture_tests/passing_test.exs
@@ -1,0 +1,10 @@
+defmodule PassingTest do
+  use ExUnit.Case
+  @moduledoc false
+
+  @moduletag fixture: true
+
+  test "passing test" do
+    assert true
+  end
+end

--- a/test/support/fixture_tests/skipped_test.exs
+++ b/test/support/fixture_tests/skipped_test.exs
@@ -1,0 +1,11 @@
+defmodule SkippedTest do
+  use ExUnit.Case
+  @moduledoc false
+
+  @moduletag fixture: true
+
+  @tag skip: true
+  test "skipped" do
+    assert true
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -4,5 +4,6 @@ Mimic.copy(Tesla)
 
 ExUnit.start(
   capture_log: true,
-  formatters: [ExUnit.CLIFormatter, BuildkiteTestCollector.Formatter]
+  formatters: [ExUnit.CLIFormatter, BuildkiteTestCollector.Formatter],
+  exclude: [fixture: true]
 )


### PR DESCRIPTION
This means tests which are skipped, invalid or excluded.  See the docs for [ExUnit.state](https://hexdocs.pm/ex_unit/1.12/ExUnit.html#t:state/0) for more information.

Fixes #4.