### PR TITLE
PIE-1354: Add collector and version to Analytics API payload

### DIFF
--- a/lib/buildkite_test_collector/ci_env.ex
+++ b/lib/buildkite_test_collector/ci_env.ex
@@ -52,6 +52,15 @@ defmodule BuildkiteTestCollector.CiEnv do
   """
   @callback message() :: nil | String.t()
 
+  @doc """
+  Name of test collector
+  """
+  @callback collector() :: String.t()
+  @doc """
+  Version of test collector
+  """
+  @callback version() :: String.t()
+
   @optional_callbacks url: 0, branch: 0, commit_sha: 0, number: 0, job_id: 0, message: 0
 
   @doc """

--- a/lib/buildkite_test_collector/ci_env/buildkite.ex
+++ b/lib/buildkite_test_collector/ci_env/buildkite.ex
@@ -35,4 +35,10 @@ defmodule BuildkiteTestCollector.CiEnv.Buildkite do
 
   @impl true
   def message, do: System.get_env("BUILDKITE_MESSAGE")
+
+  @impl true
+  def collector, do: BuildkiteTestCollector.MixProject.collector_name()
+
+  @impl true
+  def version, do: BuildkiteTestCollector.MixProject.version()
 end

--- a/lib/buildkite_test_collector/ci_env/circle_ci.ex
+++ b/lib/buildkite_test_collector/ci_env/circle_ci.ex
@@ -34,4 +34,10 @@ defmodule BuildkiteTestCollector.CiEnv.CircleCi do
 
   @impl true
   def number, do: System.get_env("CIRCLE_BUILD_NUM")
+
+  @impl true
+  def collector, do: BuildkiteTestCollector.MixProject.collector_name()
+
+  @impl true
+  def version, do: BuildkiteTestCollector.MixProject.version()
 end

--- a/lib/buildkite_test_collector/ci_env/generic.ex
+++ b/lib/buildkite_test_collector/ci_env/generic.ex
@@ -20,4 +20,10 @@ defmodule BuildkiteTestCollector.CiEnv.Generic do
 
   @impl true
   def key, do: Ecto.UUID.generate()
+
+  @impl true
+  def collector, do: BuildkiteTestCollector.MixProject.collector_name()
+
+  @impl true
+  def version, do: BuildkiteTestCollector.MixProject.version()
 end

--- a/lib/buildkite_test_collector/ci_env/github_actions.ex
+++ b/lib/buildkite_test_collector/ci_env/github_actions.ex
@@ -37,4 +37,10 @@ defmodule BuildkiteTestCollector.CiEnv.GithubActions do
 
   @impl true
   def number, do: System.get_env("GITHUB_RUN_NUMBER")
+
+  @impl true
+  def collector, do: BuildkiteTestCollector.MixProject.collector_name()
+
+  @impl true
+  def version, do: BuildkiteTestCollector.MixProject.version()
 end

--- a/lib/buildkite_test_collector/ci_env/local.ex
+++ b/lib/buildkite_test_collector/ci_env/local.ex
@@ -20,4 +20,10 @@ defmodule BuildkiteTestCollector.CiEnv.Local do
 
   @impl true
   def key, do: Ecto.UUID.generate()
+
+  @impl true
+  def collector, do: BuildkiteTestCollector.MixProject.collector_name()
+
+  @impl true
+  def version, do: BuildkiteTestCollector.MixProject.version()
 end

--- a/lib/buildkite_test_collector/payload.ex
+++ b/lib/buildkite_test_collector/payload.ex
@@ -22,7 +22,9 @@ defmodule BuildkiteTestCollector.Payload do
           optional(:branch) => String.t(),
           optional(:commit_sha) => String.t(),
           optional(:message) => String.t(),
-          optional(:url) => String.t()
+          optional(:url) => String.t(),
+          required(:collector) => String.t(),
+          required(:version) => String.t()
         }
 
   @doc """
@@ -52,7 +54,7 @@ defmodule BuildkiteTestCollector.Payload do
   def set_start_time(%Payload{} = payload, started_at), do: %{payload | started_at: started_at}
 
   defp serialise_env(ci_env_mod) do
-    ~w[CI key number job_id branch commit_sha message url]a
+    ~w[CI key number job_id branch commit_sha message url collector version]a
     |> Enum.reduce(%{}, fn
       :CI, env -> Map.put(env, :CI, ci_env_mod.ci())
       key, env -> Map.put(env, key, apply(ci_env_mod, key, []))

--- a/mix.exs
+++ b/mix.exs
@@ -2,11 +2,14 @@ defmodule BuildkiteTestCollector.MixProject do
   use Mix.Project
   @moduledoc false
 
-  @version "0.2.0"
+  @version "0.2.2"
+  def version, do: @version
+  @collector_name :buildkite_test_collector
+  def collector_name, do: "elixir-#{@collector_name}"
 
   def project do
     [
-      app: :buildkite_test_collector,
+      app: @collector_name,
       description: "Official Buildkite Test Analytics Collector",
       version: @version,
       elixir: "~> 1.13",

--- a/test/buildkite_test_collector/payload_test.exs
+++ b/test/buildkite_test_collector/payload_test.exs
@@ -22,6 +22,8 @@ defmodule BuildkiteTestCollector.PayloadTest do
       assert run_env.message == env["BUILDKITE_MESSAGE"]
       assert run_env.url =~ "http"
       assert run_env.url =~ env["BUILDKITE_BUILD_ID"]
+      assert run_env.collector == BuildkiteTestCollector.MixProject.collector_name()
+      assert run_env.version == BuildkiteTestCollector.MixProject.version()
     end
 
     test "it initialises with empty data" do


### PR DESCRIPTION
### Context

TA is working on displaying a tally of the types of collectors our customers are using. We can gather this data via the collector names and versions, however some collectors are missing this data (please see [related linear ticket](https://linear.app/buildkite/issue/PIE-435/store-collector-type-junit-rspec-etc) for list).

----

I am unfamilar with Elixir: I created constants in the `mix.exs`. There is probably a better way to do this, there seemed to be a lot of discourse about how to declare + share constants in Elixir, so happy to make suggested changes.

This PR does not include the necessary version bump, the release process can be completed once this is merged.

This collector will now emit the collector name "**elixir-buildkite_test_collector**"

---

### Linear tickets

[Linear Ticket](https://linear.app/buildkite/issue/PIE-1354/add-collector-name-and-version-to-elixir-test-collector)
[Related Linear Ticket](https://linear.app/buildkite/issue/PIE-435/store-collector-type-junit-rspec-etc)