### PR TITLE
chore: Update the `actions/cache` version.

### DIFF
--- a/.github/workflows/mix_credo.yml
+++ b/.github/workflows/mix_credo.yml
@@ -22,7 +22,7 @@ jobs:
           elixir-version: ${{ matrix.elixir }}
           otp-version: ${{ matrix.otp }}
       - name: Retrieve Mix Dependencies Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         id: mix-cache
         with:
           path: deps

--- a/.github/workflows/mix_doctor.yml
+++ b/.github/workflows/mix_doctor.yml
@@ -22,7 +22,7 @@ jobs:
           elixir-version: ${{ matrix.elixir }}
           otp-version: ${{ matrix.otp }}
       - name: Retrieve Mix Dependencies Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         id: mix-cache
         with:
           path: deps

--- a/.github/workflows/mix_format.yml
+++ b/.github/workflows/mix_format.yml
@@ -22,7 +22,7 @@ jobs:
           elixir-version: ${{ matrix.elixir }}
           otp-version: ${{ matrix.otp }}
       - name: Retrieve Mix Dependencies Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         id: mix-cache
         with:
           path: deps

--- a/.github/workflows/mix_git_ops.yml
+++ b/.github/workflows/mix_git_ops.yml
@@ -15,7 +15,7 @@ jobs:
           elixir-version: "1.15.7"
           otp-version: "26.1.2"
       - name: Retrieve Mix Dependencies Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         id: mix-cache
         with:
           path: deps

--- a/.github/workflows/mix_hex_audit.yml
+++ b/.github/workflows/mix_hex_audit.yml
@@ -21,7 +21,7 @@ jobs:
           elixir-version: ${{ matrix.elixir }}
           otp-version: ${{ matrix.otp }}
       - name: Retrieve Mix Dependencies Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         id: mix-cache
         with:
           path: deps

--- a/.github/workflows/mix_test.yml
+++ b/.github/workflows/mix_test.yml
@@ -23,7 +23,7 @@ jobs:
           elixir-version: ${{ matrix.elixir }}
           otp-version: ${{ matrix.otp }}
       - name: Retrieve Mix Dependencies Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         id: mix-cache
         with:
           path: deps


### PR DESCRIPTION
Updates the version of the `actions/cache` GitHub action so that our CI continues to pass.